### PR TITLE
feat(cli): Automate full-load data acquisition

### DIFF
--- a/src/py_load_spl/acquisition.py
+++ b/src/py_load_spl/acquisition.py
@@ -2,7 +2,6 @@ import hashlib
 import logging
 import re
 from pathlib import Path
-from typing import List
 
 import requests
 from bs4 import BeautifulSoup
@@ -22,7 +21,7 @@ from .models import Archive
 logger = logging.getLogger(__name__)
 
 
-def get_archive_list(settings: Settings) -> List[Archive]:
+def get_archive_list(settings: Settings) -> list[Archive]:
     """
     Scrapes the DailyMed SPL download page to get a list of all available archives.
     """
@@ -35,7 +34,7 @@ def get_archive_list(settings: Settings) -> List[Archive]:
         raise
 
     soup = BeautifulSoup(response.content, "lxml")
-    archives: List[Archive] = []
+    archives: list[Archive] = []
 
     # Find all list items in the download sections
     for li in soup.select("ul.download > li"):
@@ -60,7 +59,10 @@ def get_archive_list(settings: Settings) -> List[Archive]:
             )
 
     if not archives:
-        logger.warning("Could not find any archives on the page. The page structure may have changed.")
+        logger.warning(
+            "Could not find any archives on the page. "
+            "The page structure may have changed."
+        )
     else:
         logger.info("Found %d archives to process.", len(archives))
     return archives
@@ -93,7 +95,9 @@ def download_archive(archive: Archive, settings: Settings) -> Path:
         with requests.get(archive.url, stream=True, timeout=300) as r:
             r.raise_for_status()
             total_size = int(r.headers.get("content-length", 0))
-            task_id = progress.add_task("download", total=total_size, filename=archive.name)
+            task_id = progress.add_task(
+                "download", total=total_size, filename=archive.name
+            )
             with open(file_path, "wb") as f, progress:
                 for chunk in r.iter_content(chunk_size=8192):
                     f.write(chunk)
@@ -117,7 +121,7 @@ def download_archive(archive: Archive, settings: Settings) -> Path:
         raise
 
 
-def download_spl_archives(loader: DatabaseLoader) -> List[Archive]:
+def download_spl_archives(loader: DatabaseLoader) -> list[Archive]:
     """
     Main function for F001: Data Acquisition.
 
@@ -150,7 +154,9 @@ def download_spl_archives(loader: DatabaseLoader) -> List[Archive]:
 
     # Determine which archives are new
     all_available_archives_map = {a.name: a for a in all_available_archives}
-    new_archive_names = set(all_available_archives_map.keys()) - processed_archives_names
+    new_archive_names = (
+        set(all_available_archives_map.keys()) - processed_archives_names
+    )
 
     if not new_archive_names:
         logger.info("No new archives to download. Database is up to date.")
@@ -159,21 +165,70 @@ def download_spl_archives(loader: DatabaseLoader) -> List[Archive]:
     logger.info(f"Found {len(new_archive_names)} new archives to download.")
 
     # Download each new archive
-    downloaded_archives: List[Archive] = []
+    downloaded_archives: list[Archive] = []
     # Sort for deterministic download order, useful for testing/logging
-    for name in sorted(list(new_archive_names)):
+    for name in sorted(new_archive_names):
         archive_to_download = all_available_archives_map[name]
         try:
             download_archive(archive_to_download, settings)
             downloaded_archives.append(archive_to_download)
         except Exception as e:
             logger.error(
-                f"Failed to download archive {name}. Skipping. Error: {e}", exc_info=True
+                f"Failed to download archive {name}. Skipping. Error: {e}",
+                exc_info=True,
             )
             # Continue to the next file
             continue
 
     logger.info(
         f"Data acquisition step completed. Downloaded {len(downloaded_archives)} files."
+    )
+    return downloaded_archives
+
+
+def download_all_archives(settings: Settings | None = None) -> list[Archive]:
+    """
+    Main function for downloading ALL SPL archives for a full load.
+
+    This is a non-stateful download. It gets the full list of archives
+    from the FDA source and attempts to download every single one.
+
+    Returns:
+        A list of Archive objects that were newly downloaded.
+    """
+    logger.info("Starting download of all SPL data for full load...")
+    if settings is None:
+        settings = get_settings()
+
+    # Get all available archives from the source
+    all_available_archives = get_archive_list(settings)
+    if not all_available_archives:
+        logger.warning("No archives found at source. Nothing to download.")
+        return []
+
+    logger.info(f"Found {len(all_available_archives)} total archives to download.")
+
+    # Download each archive
+    downloaded_archives: list[Archive] = []
+    # Sort for deterministic download order, useful for testing/logging
+    for archive_to_download in sorted(all_available_archives, key=lambda a: a.name):
+        try:
+            download_archive(archive_to_download, settings)
+            downloaded_archives.append(archive_to_download)
+        except Exception as e:
+            logger.error(
+                (
+                    f"Failed to download archive {archive_to_download.name}. "
+                    f"Skipping. Error: {e}"
+                ),
+                exc_info=True,
+            )
+            # Continue to the next file
+            continue
+
+    logger.info(
+        "Full data acquisition step completed. Downloaded %d of %d files.",
+        len(downloaded_archives),
+        len(all_available_archives),
     )
     return downloaded_archives

--- a/src/py_load_spl/cli.py
+++ b/src/py_load_spl/cli.py
@@ -9,6 +9,7 @@ import typer
 from rich.console import Console
 
 from . import __name__ as app_name
+from .acquisition import download_all_archives, download_spl_archives
 from .config import Settings, get_settings
 from .db.base import DatabaseLoader
 from .db.postgres import PostgresLoader
@@ -19,7 +20,7 @@ from .transformation import (
     ParquetWriter,
     Transformer,
 )
-from .util import setup_logging
+from .util import setup_logging, unzip_archive
 
 app = typer.Typer(name=app_name)
 console = Console()
@@ -50,21 +51,28 @@ def main(
         settings.intermediate_format = intermediate_format
     ctx.obj = settings
     if ctx.invoked_subcommand is None:
-        console.print("[bold red]No command specified. Use --help for options.[/bold red]")
+        console.print(
+            "[bold red]No command specified. Use --help for options.[/bold red]"
+        )
 
 
 def get_db_loader(settings: Settings) -> DatabaseLoader:
     if settings.db.adapter == "postgresql":
         return PostgresLoader(settings.db)
     else:
-        console.print(f"[bold red]Error: Unsupported DB adapter '{settings.db.adapter}'[/bold red]")
+        console.print(
+            f"[bold red]Error: Unsupported DB adapter "
+            f"'{settings.db.adapter}'[/bold red]"
+        )
         raise typer.Exit(1)
 
 
 def get_file_writer(settings: Settings, output_dir: Path) -> FileWriter:
     """Instantiates the correct file writer based on settings."""
     if settings.intermediate_format == "parquet":
-        console.print("[bold blue]Using Parquet format for intermediate files.[/bold blue]")
+        console.print(
+            "[bold blue]Using Parquet format for intermediate files.[/bold blue]"
+        )
         return ParquetWriter(output_dir)
     elif settings.intermediate_format == "csv":
         console.print("[bold blue]Using CSV format for intermediate files.[/bold blue]")
@@ -72,13 +80,16 @@ def get_file_writer(settings: Settings, output_dir: Path) -> FileWriter:
     else:
         # This case should be prevented by Pydantic validation, but as a safeguard:
         console.print(
-            f"[bold red]Error: Unsupported intermediate format '{settings.intermediate_format}'[/bold red]"
+            "[bold red]Error: Unsupported intermediate format "
+            f"'{settings.intermediate_format}'[/bold red]"
         )
         raise typer.Exit(1)
 
 
 def _quarantine_and_parse_in_parallel(
-    xml_files: list[Path], settings: Settings, executor: concurrent.futures.ProcessPoolExecutor
+    xml_files: list[Path],
+    settings: Settings,
+    executor: concurrent.futures.ProcessPoolExecutor,
 ):
     """
     Parses a list of XML files in parallel, quarantining any file that fails.
@@ -99,11 +110,15 @@ def _quarantine_and_parse_in_parallel(
                 shutil.move(str(source_file_path), str(target_path))
                 quarantined_count += 1
                 logging.warning(
-                    f"Moved corrupted file {source_file_path.name} to {target_path} due to parsing error: {e}"
+                    "Moved corrupted file %s to %s due to parsing error: %s",
+                    source_file_path.name,
+                    target_path,
+                    e,
                 )
             else:
                 logging.warning(
-                    f"Could not quarantine {source_file_path.name} as it was already moved or deleted."
+                    "Could not quarantine %s as it was already moved or deleted.",
+                    source_file_path.name,
                 )
 
     if quarantined_count > 0:
@@ -123,23 +138,11 @@ def init(ctx: typer.Context) -> None:
         console.print("[bold green]Schema initialization complete.[/bold green]")
     except Exception as e:
         console.print(f"[bold red]Schema initialization failed: {e}[/bold red]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
 
-@app.command()
-def full_load(
-    ctx: typer.Context,
-    source: Path = typer.Option(
-        ...,
-        help="Local path to the directory containing SPL XML files.",
-        exists=True,
-        file_okay=False,
-        dir_okay=True,
-        readable=True,
-    ),
-) -> None:
-    """F008.3: Perform a full data load from a local directory."""
-    settings: Settings = ctx.obj
+def _run_full_load(settings: Settings, source: Path):
+    """The core logic for a full data load from a given source directory."""
     console.print(f"[bold cyan]Starting full data load from '{source}'...[/bold cyan]")
     loader = get_db_loader(settings)
     run_id = None
@@ -153,10 +156,21 @@ def full_load(
 
             console.print("[cyan]Step 1: Finding XML files...[/cyan]")
             xml_files = list(source.glob("**/*.xml"))
+            if not xml_files:
+                console.print(
+                    "[bold yellow]No XML files found in the source. "
+                    "Aborting.[/bold yellow]"
+                )
+                if run_id:
+                    loader.end_run(
+                        run_id, "SUCCESS", 0, None
+                    )  # End run with 0 records
+                return
             console.print(f"Found {len(xml_files)} XML files to process.")
 
             console.print(
-                f"[cyan]Step 2: Parsing and Transforming in parallel (max_workers={settings.max_workers})...[/cyan]"
+                "[cyan]Step 2: Parsing and Transforming in parallel "
+                f"(max_workers={settings.max_workers})...[/cyan]"
             )
             with concurrent.futures.ProcessPoolExecutor(
                 max_workers=settings.max_workers
@@ -178,17 +192,88 @@ def full_load(
 
         if run_id:
             total_records = sum(stats.values()) if stats else 0
-            loader.end_run(run_id, "SUCCESS", total_records)
-        console.print("[bold green]Full load process finished successfully.[/bold green]")
+            loader.end_run(run_id, "SUCCESS", total_records, None)
+        console.print(
+            "[bold green]Full load process finished successfully.[/bold green]"
+        )
     except Exception as e:
-        console.print(f"[bold red]An error occurred during the full load process: {e}[/bold red]")
+        console.print(
+            f"[bold red]An error occurred during the full load process: {e}[/bold red]"
+        )
         if run_id:
             loader.end_run(run_id, "FAILED", 0, str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
 
-from .acquisition import download_spl_archives
-from .util import unzip_archive
+@app.command()
+def full_load(
+    ctx: typer.Context,
+    source: Path | None = typer.Option(
+        None,
+        help=(
+            "Local path to SPL XML files. If not provided, all archives will be "
+            "downloaded from the FDA source."
+        ),
+        file_okay=False,
+        dir_okay=True,
+        readable=True,
+        resolve_path=True,
+    ),
+) -> None:
+    """
+    F008.3: Perform a full data load from a local directory or by downloading all
+    archives.
+    """
+    settings: Settings = ctx.obj
+
+    if source:
+        if not source.exists():
+            console.print(
+                f"[bold red]Error: Source path '{source}' does not exist.[/bold red]"
+            )
+            raise typer.Exit(1)
+        # Run the load process directly on the user-provided directory
+        _run_full_load(settings, source)
+    else:
+        # No source provided, so download everything.
+        console.print(
+            "[bold cyan]Step 0: No source path provided. Downloading all "
+            "archives from FDA source...[/bold cyan]"
+        )
+
+        with (
+            tempfile.TemporaryDirectory() as download_dir,
+            tempfile.TemporaryDirectory() as xml_dir,
+        ):
+            # Temporarily override download_path setting so archives go into our
+            # temp dir
+            original_download_path = settings.download_path
+            settings.download_path = download_dir
+
+            try:
+                downloaded_archives = download_all_archives(settings)
+
+                if not downloaded_archives:
+                    console.print(
+                        "[bold yellow]No archives were downloaded. "
+                        "Nothing to do.[/bold yellow]"
+                    )
+                    return
+
+                xml_dir_path = Path(xml_dir)
+                console.print(
+                    f"[cyan]Extracting {len(downloaded_archives)} archives to "
+                    f"{xml_dir_path}...[/cyan]"
+                )
+                for archive in downloaded_archives:
+                    archive_path = Path(settings.download_path) / archive.name
+                    unzip_archive(archive_path, xml_dir_path)
+
+                # Now run the load process on the extracted files
+                _run_full_load(settings, xml_dir_path)
+            finally:
+                # Always restore the original setting
+                settings.download_path = original_download_path
 
 
 @app.command()
@@ -202,32 +287,44 @@ def delta_load(ctx: typer.Context) -> None:
     try:
         run_id = loader.start_run(mode="delta-load")
 
-        console.print("[cyan]Step 1: Checking for and downloading new archives...[/cyan]")
+        console.print(
+            "[cyan]Step 1: Checking for and downloading new archives...[/cyan]"
+        )
         downloaded_archives = download_spl_archives(loader)
         if not downloaded_archives:
-            console.print("[green]No new archives found. Database is up-to-date.[/green]")
-            loader.end_run(run_id, "SUCCESS", 0)
+            console.print(
+                "[green]No new archives found. Database is up-to-date.[/green]"
+            )
+            loader.end_run(run_id, "SUCCESS", 0, None)
             return
-        console.print(f"[green]Downloaded {len(downloaded_archives)} new archive(s).[/green]")
+        console.print(
+            f"[green]Downloaded {len(downloaded_archives)} new archive(s).[/green]"
+        )
 
-        with tempfile.TemporaryDirectory() as xml_temp_dir_str, \
-             tempfile.TemporaryDirectory() as intermediate_dir_str:
-
+        with (
+            tempfile.TemporaryDirectory() as xml_temp_dir_str,
+            tempfile.TemporaryDirectory() as intermediate_dir_str,
+        ):
             xml_temp_dir = Path(xml_temp_dir_str)
             intermediate_dir = Path(intermediate_dir_str)
             writer = get_file_writer(settings, intermediate_dir)
 
-            console.print(f"[cyan]Step 2: Extracting XML files to {xml_temp_dir}...[/cyan]")
+            console.print(
+                f"[cyan]Step 2: Extracting XML files to {xml_temp_dir}...[/cyan]"
+            )
             for archive in downloaded_archives:
                 archive_path = Path(settings.download_path) / archive.name
                 unzip_archive(archive_path, xml_temp_dir)
 
-            console.print(f"[cyan]Step 3: Finding XML files in {xml_temp_dir}...[/cyan]")
+            console.print(
+                f"[cyan]Step 3: Finding XML files in {xml_temp_dir}...[/cyan]"
+            )
             xml_files = list(xml_temp_dir.glob("**/*.xml"))
             console.print(f"Found {len(xml_files)} XML files to process.")
 
             console.print(
-                f"[cyan]Step 4: Parsing and Transforming in parallel (max_workers={settings.max_workers})...[/cyan]"
+                "[cyan]Step 4: Parsing and Transforming in parallel "
+                f"(max_workers={settings.max_workers})...[/cyan]"
             )
             with concurrent.futures.ProcessPoolExecutor(
                 max_workers=settings.max_workers
@@ -246,21 +343,27 @@ def delta_load(ctx: typer.Context) -> None:
             loader.post_load_cleanup(mode="delta-load")
             console.print("[green]Database loading complete.[/green]")
 
-            console.print("[cyan]Step 6: Recording processed archives in database...[/cyan]")
+            console.print(
+                "[cyan]Step 6: Recording processed archives in database...[/cyan]"
+            )
             for archive in downloaded_archives:
                 loader.record_processed_archive(archive.name, archive.checksum)
 
         if run_id:
             total_records = sum(stats.values()) if stats else 0
-            loader.end_run(run_id, "SUCCESS", total_records)
-        console.print("[bold green]Delta load process finished successfully.[/bold green]")
+            loader.end_run(run_id, "SUCCESS", total_records, None)
+        console.print(
+            "[bold green]Delta load process finished successfully.[/bold green]"
+        )
 
     except Exception as e:
-        console.print(f"[bold red]An error occurred during the delta load process: {e}[/bold red]")
+        console.print(
+            f"[bold red]An error occurred during the delta load process: {e}[/bold red]"
+        )
         logging.getLogger(__name__).exception("Delta load failed")
         if run_id:
             loader.end_run(run_id, "FAILED", 0, str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
 
 if __name__ == "__main__":

--- a/src/py_load_spl/config.py
+++ b/src/py_load_spl/config.py
@@ -33,7 +33,9 @@ class Settings(BaseSettings):
     log_level: str = "INFO"
     data_dir: str = "data"
     # The FRD requires a configurable download source (F001.1)
-    fda_source_url: HttpUrl = "https://dailymed.nlm.nih.gov/dailymed/spl-resources-all-drug-labels.cfm"  # type: ignore
+    fda_source_url: HttpUrl = (
+        "https://dailymed.nlm.nih.gov/dailymed/spl-resources-all-drug-labels.cfm"  # type: ignore
+    )
     download_path: str = "data/downloads"
     quarantine_path: str = Field(
         default="data/quarantine",

--- a/src/py_load_spl/db/base.py
+++ b/src/py_load_spl/db/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Literal
+from typing import Literal
 
 
 class DatabaseLoader(ABC):
@@ -24,7 +24,7 @@ class DatabaseLoader(ABC):
         pass
 
     @abstractmethod
-    def pre_load_optimization(self) -> None:
+    def pre_load_optimization(self, mode: Literal["full-load", "delta-load"]) -> None:
         """Optional: Drop indexes, disable constraints (for full loads)."""
         pass
 
@@ -37,7 +37,7 @@ class DatabaseLoader(ABC):
         pass
 
     @abstractmethod
-    def post_load_cleanup(self) -> None:
+    def post_load_cleanup(self, mode: Literal["full-load", "delta-load"]) -> None:
         """Optional: Rebuild indexes, enable constraints, vacuum/analyze."""
         pass
 

--- a/src/py_load_spl/db/postgres.py
+++ b/src/py_load_spl/db/postgres.py
@@ -1,7 +1,8 @@
 import logging
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Generator, Literal
+from typing import Any, Literal
 
 import psycopg2
 from psycopg2.extensions import connection
@@ -79,7 +80,9 @@ class PostgresLoader(DatabaseLoader):
                     cur.execute(sql)
                     # Use a set comprehension for efficiency
                     processed_archives = {row[0] for row in cur.fetchall()}
-            logger.info(f"Found {len(processed_archives)} previously processed archives.")
+            logger.info(
+                f"Found {len(processed_archives)} previously processed archives."
+            )
             return processed_archives
         except psycopg2.Error as e:
             logger.error(f"Failed to fetch processed archives: {e}")
@@ -148,11 +151,11 @@ class PostgresLoader(DatabaseLoader):
                             COPY {table_name} {column_spec} FROM STDIN
                             WITH (FORMAT CSV, NULL '\\N', QUOTE '\"');
                         """
-                        with open(filepath, "r", encoding="utf-8") as f:
+                        with open(filepath, encoding="utf-8") as f:
                             cur.copy_expert(sql, f)
                 conn.commit()
             logger.info("Bulk load to staging tables complete.")
-        except (psycopg2.Error, IOError) as e:
+        except (OSError, psycopg2.Error) as e:
             logger.error(f"Bulk load to staging failed: {e}")
             if self.conn:
                 self.conn.rollback()
@@ -199,7 +202,9 @@ class PostgresLoader(DatabaseLoader):
             logger.warning("No optimizable objects found to drop.")
             return
 
-        logger.info(f"Dropping {len(self.dropped_object_definitions)} indexes and foreign keys...")
+        logger.info(
+            f"Dropping {len(self.dropped_object_definitions)} indexes and foreign keys..."
+        )
         # Drop foreign keys first
         cur.execute("""
             SELECT 'ALTER TABLE ' || n.nspname || '."' || conrel.relname || '" DROP CONSTRAINT "' || c.conname || '";'
@@ -235,7 +240,9 @@ class PostgresLoader(DatabaseLoader):
             logger.warning("No stored object definitions to recreate.")
             return
 
-        logger.info(f"Recreating {len(self.dropped_object_definitions)} indexes and foreign keys...")
+        logger.info(
+            f"Recreating {len(self.dropped_object_definitions)} indexes and foreign keys..."
+        )
         for definition in self.dropped_object_definitions:
             logger.debug(f"Executing: {definition}")
             cur.execute(definition)
@@ -301,40 +308,79 @@ class PostgresLoader(DatabaseLoader):
                         logger.info("Inserting all data from staging...")
                         for table in tables_in_dependency_order:
                             logger.debug(f"Loading data into {table}...")
-                            cur.execute(f"INSERT INTO {table} SELECT * FROM {table}_staging;")
+                            cur.execute(
+                                f"INSERT INTO {table} SELECT * FROM {table}_staging;"
+                            )
 
                     elif mode == "delta-load":
                         logger.info("Performing delta merge (UPSERT)...")
                         # 1. UPSERT spl_raw_documents
-                        update_cols_raw = ["set_id", "version_number", "effective_time", "raw_data", "source_filename", "loaded_at"]
-                        update_clause_raw = ", ".join([f"{col} = EXCLUDED.{col}" for col in update_cols_raw])
+                        update_cols_raw = [
+                            "set_id",
+                            "version_number",
+                            "effective_time",
+                            "raw_data",
+                            "source_filename",
+                            "loaded_at",
+                        ]
+                        update_clause_raw = ", ".join(
+                            [f"{col} = EXCLUDED.{col}" for col in update_cols_raw]
+                        )
                         cur.execute(f"""
                             INSERT INTO spl_raw_documents SELECT * FROM spl_raw_documents_staging
                             ON CONFLICT (document_id) DO UPDATE SET {update_clause_raw};
                         """)
 
                         # 2. UPSERT products
-                        update_cols_prod = ["set_id", "version_number", "effective_time", "product_name", "manufacturer_name", "dosage_form", "route_of_administration", "is_latest_version", "loaded_at"]
-                        update_clause_prod = ", ".join([f"{col} = EXCLUDED.{col}" for col in update_cols_prod])
+                        update_cols_prod = [
+                            "set_id",
+                            "version_number",
+                            "effective_time",
+                            "product_name",
+                            "manufacturer_name",
+                            "dosage_form",
+                            "route_of_administration",
+                            "is_latest_version",
+                            "loaded_at",
+                        ]
+                        update_clause_prod = ", ".join(
+                            [f"{col} = EXCLUDED.{col}" for col in update_cols_prod]
+                        )
                         cur.execute(f"""
                             INSERT INTO products SELECT * FROM products_staging
                             ON CONFLICT (document_id) DO UPDATE SET {update_clause_prod};
                         """)
 
                         # 3. DELETE-INSERT for child tables
-                        cur.execute("SELECT DISTINCT document_id FROM products_staging;")
+                        cur.execute(
+                            "SELECT DISTINCT document_id FROM products_staging;"
+                        )
                         doc_ids_to_update = tuple([row[0] for row in cur.fetchall()])
 
                         if doc_ids_to_update:
-                            child_tables = ["product_ndcs", "ingredients", "packaging", "marketing_status"]
+                            child_tables = [
+                                "product_ndcs",
+                                "ingredients",
+                                "packaging",
+                                "marketing_status",
+                            ]
                             for table in child_tables:
-                                logger.debug(f"Replacing child records in {table} for updated documents...")
-                                cur.execute(f"DELETE FROM {table} WHERE document_id IN %s;", (doc_ids_to_update,))
-                                cur.execute(f"INSERT INTO {table} SELECT * FROM {table}_staging;")
+                                logger.debug(
+                                    f"Replacing child records in {table} for updated documents..."
+                                )
+                                cur.execute(
+                                    f"DELETE FROM {table} WHERE document_id IN %s;",
+                                    (doc_ids_to_update,),
+                                )
+                                cur.execute(
+                                    f"INSERT INTO {table} SELECT * FROM {table}_staging;"
+                                )
 
                     # Final step: Update the is_latest_version flag for all affected products.
                     # This is done for both full and delta loads to ensure consistency.
-                    logger.info("Updating is_latest_version flag for all affected products...")
+                    logger.info(
+                        "Updating is_latest_version flag for all affected products..."
+                    )
                     cur.execute("""
                         WITH affected_set_ids AS (
                             SELECT DISTINCT set_id FROM products_staging
@@ -421,7 +467,11 @@ class PostgresLoader(DatabaseLoader):
             raise
 
     def end_run(
-        self, run_id: int, status: str, records_loaded: int = 0, error_log: str | None = None
+        self,
+        run_id: int,
+        status: str,
+        records_loaded: int = 0,
+        error_log: str | None = None,
     ) -> None:
         """Updates the etl_load_history record for the completed run."""
         logger.info(f"Ending ETL run {run_id} with status: {status}")

--- a/src/py_load_spl/parsing.py
+++ b/src/py_load_spl/parsing.py
@@ -1,5 +1,4 @@
 import logging
-from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 
@@ -40,7 +39,7 @@ def parse_spl_file(file_path: Path) -> dict[str, Any]:
 
     try:
         raw_xml_content = file_path.read_text(encoding="utf-8")
-    except IOError as e:
+    except OSError as e:
         logger.error(f"Could not read file {file_path}: {e}")
         raise
 
@@ -72,18 +71,33 @@ def parse_spl_file(file_path: Path) -> dict[str, Any]:
             if product_element is not None:
                 # Extract product details
                 product_name_el = _xp(product_element, ".//hl7:name")
-                data["product_name"] = product_name_el.text if product_name_el is not None else None
+                data["product_name"] = (
+                    product_name_el.text if product_name_el is not None else None
+                )
 
                 dosage_form_el = _xp(product_element, ".//hl7:formCode")
-                data["dosage_form"] = dosage_form_el.get("displayName") if dosage_form_el is not None else None
+                data["dosage_form"] = (
+                    dosage_form_el.get("displayName")
+                    if dosage_form_el is not None
+                    else None
+                )
 
                 route_code_el = _xp(product_element, ".//hl7:routeCode")
-                data["route_of_administration"] = route_code_el.get("displayName") if route_code_el is not None else None
+                data["route_of_administration"] = (
+                    route_code_el.get("displayName")
+                    if route_code_el is not None
+                    else None
+                )
 
                 # Extract Product NDCs
-                as_equivalent_entity_el = _xp(product_element, "./hl7:asEquivalentEntity")
+                as_equivalent_entity_el = _xp(
+                    product_element, "./hl7:asEquivalentEntity"
+                )
                 if as_equivalent_entity_el is not None:
-                    for code_el in _xpa(as_equivalent_entity_el, "./hl7:code[@codeSystem='2.16.840.1.113883.6.69']"):
+                    for code_el in _xpa(
+                        as_equivalent_entity_el,
+                        "./hl7:code[@codeSystem='2.16.840.1.113883.6.69']",
+                    ):
                         if ndc_code := code_el.get("code"):
                             data["product_ndcs"].append({"ndc_code": ndc_code})
 
@@ -91,22 +105,49 @@ def parse_spl_file(file_path: Path) -> dict[str, Any]:
                 for ingredient_el in _xpa(product_element, ".//hl7:ingredient"):
                     substance = _xp(ingredient_el, ".//hl7:ingredientSubstance")
                     quantity = _xp(ingredient_el, ".//hl7:quantity")
-                    numerator = _xp(quantity, ".//hl7:numerator") if quantity is not None else None
-                    denominator = _xp(quantity, ".//hl7:denominator") if quantity is not None else None
-                    substance_name_el = _xp(substance, ".//hl7:name") if substance is not None else None
-                    substance_code_el = _xp(substance, ".//hl7:code") if substance is not None else None
-                    data["ingredients"].append({
-                        "ingredient_name": substance_name_el.text if substance_name_el is not None else None,
-                        "substance_code": substance_code_el.get("code") if substance_code_el is not None else None,
-                        "is_active_ingredient": ingredient_el.get("classCode") == "ACT",
-                        "strength_numerator": numerator.get("value") if numerator is not None else None,
-                        "strength_denominator": denominator.get("value") if denominator is not None else None,
-                        "unit_of_measure": numerator.get("unit") if numerator is not None else None,
-                    })
+                    numerator = (
+                        _xp(quantity, ".//hl7:numerator")
+                        if quantity is not None
+                        else None
+                    )
+                    denominator = (
+                        _xp(quantity, ".//hl7:denominator")
+                        if quantity is not None
+                        else None
+                    )
+                    substance_name_el = (
+                        _xp(substance, ".//hl7:name") if substance is not None else None
+                    )
+                    substance_code_el = (
+                        _xp(substance, ".//hl7:code") if substance is not None else None
+                    )
+                    data["ingredients"].append(
+                        {
+                            "ingredient_name": substance_name_el.text
+                            if substance_name_el is not None
+                            else None,
+                            "substance_code": substance_code_el.get("code")
+                            if substance_code_el is not None
+                            else None,
+                            "is_active_ingredient": ingredient_el.get("classCode")
+                            == "ACT",
+                            "strength_numerator": numerator.get("value")
+                            if numerator is not None
+                            else None,
+                            "strength_denominator": denominator.get("value")
+                            if denominator is not None
+                            else None,
+                            "unit_of_measure": numerator.get("unit")
+                            if numerator is not None
+                            else None,
+                        }
+                    )
 
             # Extract manufacturer from the parent element
             manufacturer_el = _xp(parent_product_el, "./hl7:manufacturer/hl7:name")
-            data["manufacturer_name"] = manufacturer_el.text if manufacturer_el is not None else None
+            data["manufacturer_name"] = (
+                manufacturer_el.text if manufacturer_el is not None else None
+            )
 
         # Extract from the structured body for packaging and marketing status
         body = _xp(root, ".//hl7:component/hl7:structuredBody")
@@ -114,7 +155,10 @@ def parse_spl_file(file_path: Path) -> dict[str, Any]:
             # Packaging (F003.2)
             for section in _xpa(body, ".//hl7:section"):
                 code_el = _xp(section, ".//hl7:code")
-                if code_el is not None and code_el.get("code") in ('34069-5', '51945-4'):
+                if code_el is not None and code_el.get("code") in (
+                    "34069-5",
+                    "51945-4",
+                ):
                     for part_el in _xpa(section, ".//hl7:part"):
                         part_code_el = _xp(part_el, "./hl7:code")
                         if part_code_el is not None:
@@ -122,26 +166,50 @@ def parse_spl_file(file_path: Path) -> dict[str, Any]:
                             if desc_el is None:
                                 desc_el = _xp(part_el, "./hl7:desc")
                             form_code_el = _xp(part_el, "./hl7:formCode")
-                            data["packaging"].append({
-                                "package_ndc": part_code_el.get("code"),
-                                "package_description": desc_el.text if desc_el is not None else None,
-                                "package_type": form_code_el.get("displayName") if form_code_el is not None else None,
-                            })
+                            data["packaging"].append(
+                                {
+                                    "package_ndc": part_code_el.get("code"),
+                                    "package_description": desc_el.text
+                                    if desc_el is not None
+                                    else None,
+                                    "package_type": form_code_el.get("displayName")
+                                    if form_code_el is not None
+                                    else None,
+                                }
+                            )
 
             # Marketing Status
             for act in _xpa(body, ".//hl7:subject//hl7:marketingAct"):
                 status_code_el = _xp(act, "./hl7:statusCode")
                 effective_time_el = _xp(act, "./hl7:effectiveTime")
-                start_date_el = _xp(effective_time_el, "./hl7:low") if effective_time_el is not None else None
-                end_date_el = _xp(effective_time_el, "./hl7:high") if effective_time_el is not None else None
-                data["marketing_status"].append({
-                    "marketing_category": status_code_el.get("code") if status_code_el is not None else None,
-                    "start_date": start_date_el.get("value") if start_date_el is not None else None,
-                    "end_date": end_date_el.get("value") if end_date_el is not None else None,
-                })
+                start_date_el = (
+                    _xp(effective_time_el, "./hl7:low")
+                    if effective_time_el is not None
+                    else None
+                )
+                end_date_el = (
+                    _xp(effective_time_el, "./hl7:high")
+                    if effective_time_el is not None
+                    else None
+                )
+                data["marketing_status"].append(
+                    {
+                        "marketing_category": status_code_el.get("code")
+                        if status_code_el is not None
+                        else None,
+                        "start_date": start_date_el.get("value")
+                        if start_date_el is not None
+                        else None,
+                        "end_date": end_date_el.get("value")
+                        if end_date_el is not None
+                        else None,
+                    }
+                )
 
     except (AttributeError, TypeError, ValueError) as e:
-        logger.error(f"Error parsing file {file_path}. Some elements may be missing. Error: {e}")
+        logger.error(
+            f"Error parsing file {file_path}. Some elements may be missing. Error: {e}"
+        )
         raise SplParsingError(
             f"A critical error occurred during parsing: {e}", file_path=file_path
         ) from e
@@ -152,5 +220,3 @@ def parse_spl_file(file_path: Path) -> dict[str, Any]:
         del root.getparent()[0]
 
     return data
-
-

--- a/src/py_load_spl/transformation.py
+++ b/src/py_load_spl/transformation.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, IO, Type
+from typing import IO, Any
 from uuid import UUID
 
 import pyarrow as pa
@@ -24,7 +24,7 @@ from .models import (
 logger = logging.getLogger(__name__)
 
 # A mapping from our Pydantic models to the output filenames (without extension).
-MODEL_TO_FILENAME_MAP: dict[Type[BaseModel], str] = {
+MODEL_TO_FILENAME_MAP: dict[type[BaseModel], str] = {
     Product: "products",
     Ingredient: "ingredients",
     Packaging: "packaging",
@@ -34,6 +34,7 @@ MODEL_TO_FILENAME_MAP: dict[Type[BaseModel], str] = {
 }
 
 # --- Writer Abstraction ---
+
 
 class FileWriter(ABC):
     """Abstract base class for file writers."""
@@ -147,6 +148,7 @@ class ParquetWriter(FileWriter):
 
 # --- Transformer ---
 
+
 class Transformer:
     """
     Implements the transformation logic (F003, F005).
@@ -170,7 +172,9 @@ class Transformer:
             for i, record in enumerate(parsed_data_stream):
                 doc_id = record.get("document_id")
                 if not doc_id:
-                    logger.warning(f"Skipping record due to missing document_id: {record}")
+                    logger.warning(
+                        f"Skipping record due to missing document_id: {record}"
+                    )
                     continue
 
                 try:
@@ -188,7 +192,9 @@ class Transformer:
                         writer.write(ProductNdc(document_id=doc_id, **ndc_data))
 
                 except Exception as e:
-                    logger.error(f"Failed to transform record with doc_id {doc_id}. Error: {e}")
+                    logger.error(
+                        f"Failed to transform record with doc_id {doc_id}. Error: {e}"
+                    )
                     continue
 
                 if (i + 1) % 1000 == 0:

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -1,6 +1,7 @@
 import pytest
 import requests
 import requests_mock
+
 from py_load_spl.acquisition import get_archive_list
 from py_load_spl.config import Settings
 from py_load_spl.models import Archive
@@ -64,7 +65,9 @@ def test_get_archive_list_success():
     ]
 
     # Sort lists of Pydantic models to ensure comparison is order-independent
-    assert sorted(archives, key=lambda x: x.name) == sorted(expected_archives, key=lambda x: x.name)
+    assert sorted(archives, key=lambda x: x.name) == sorted(
+        expected_archives, key=lambda x: x.name
+    )
 
 
 def test_get_archive_list_http_error():
@@ -85,7 +88,9 @@ def test_get_archive_list_no_archives_found():
     """
     settings = Settings()
     with requests_mock.Mocker() as m:
-        m.get(str(settings.fda_source_url), text="<html><body>No links here</body></html>")
+        m.get(
+            str(settings.fda_source_url), text="<html><body>No links here</body></html>"
+        )
 
         archives = get_archive_list(settings)
         assert len(archives) == 0
@@ -93,6 +98,7 @@ def test_get_archive_list_no_archives_found():
 
 import hashlib
 from pathlib import Path
+
 from py_load_spl.acquisition import download_archive
 
 
@@ -111,7 +117,11 @@ def test_download_archive_success(tmp_path: Path):
     settings = Settings(download_path=str(tmp_path))
 
     with requests_mock.Mocker() as m:
-        m.get(archive.url, content=mock_content, headers={"Content-Length": str(len(mock_content))})
+        m.get(
+            archive.url,
+            content=mock_content,
+            headers={"Content-Length": str(len(mock_content))},
+        )
         result_path = download_archive(archive, settings)
 
     expected_path = tmp_path / archive.name

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,9 @@
 import pytest
-from typer.testing import CliRunner
 from testcontainers.postgres import PostgresContainer
+from typer.testing import CliRunner
 
 from py_load_spl.cli import app
-from py_load_spl.config import Settings, DatabaseSettings
+from py_load_spl.config import DatabaseSettings, Settings
 
 runner = CliRunner()
 
@@ -39,13 +39,16 @@ def test_init_command(monkeypatch: pytest.MonkeyPatch) -> None:
         result = runner.invoke(app, ["init"])
 
         # Assert success
-        assert result.exit_code == 0, f"CLI command failed with output:\n{result.stdout}"
+        assert result.exit_code == 0, (
+            f"CLI command failed with output:\n{result.stdout}"
+        )
         assert "Initializing database schema" in result.stdout
         assert "Schema initialization complete" in result.stdout
 
 
 import hashlib
 from pathlib import Path
+
 import requests_mock
 
 # A simplified HTML fixture mimicking the structure of the DailyMed page
@@ -138,17 +141,23 @@ def mock_db_loader(monkeypatch: pytest.MonkeyPatch):
 #     assert expected_file.read_bytes() == mock_content
 
 
-def test_delta_load_no_new_archives(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
+def test_delta_load_no_new_archives(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
     """
     Tests that delta-load handles the case where no new archives are found.
     """
     # Mock the functions that would perform external actions
     mock_loader_instance = MockLoader(None)
     mock_loader_instance.start_run = lambda mode: 1
-    mock_loader_instance.end_run = lambda run_id, status, count: None
+    mock_loader_instance.end_run = lambda run_id, status, count, error_log: None
 
-    monkeypatch.setattr("py_load_spl.cli.get_db_loader", lambda settings: mock_loader_instance)
-    monkeypatch.setattr("py_load_spl.cli.download_spl_archives", lambda loader: []) # No new archives
+    monkeypatch.setattr(
+        "py_load_spl.cli.get_db_loader", lambda settings: mock_loader_instance
+    )
+    monkeypatch.setattr(
+        "py_load_spl.cli.download_spl_archives", lambda loader: []
+    )  # No new archives
 
     with caplog.at_level(logging.INFO):
         result = runner.invoke(app, ["delta-load"])
@@ -158,6 +167,7 @@ def test_delta_load_no_new_archives(monkeypatch: pytest.MonkeyPatch, caplog: pyt
 
 
 import zipfile
+
 import psycopg2
 
 SAMPLE_XML_CONTENT = """<?xml version="1.0" encoding="UTF-8"?>
@@ -222,7 +232,9 @@ def test_delta_load_end_to_end(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         test_settings = Settings(db=test_db_settings, download_path=str(tmp_path))
 
         monkeypatch.setattr("py_load_spl.cli.get_settings", lambda: test_settings)
-        monkeypatch.setattr("py_load_spl.acquisition.get_settings", lambda: test_settings)
+        monkeypatch.setattr(
+            "py_load_spl.acquisition.get_settings", lambda: test_settings
+        )
 
         # 3. Run the 'init' command first to set up the schema
         init_result = runner.invoke(app, ["init"])
@@ -232,7 +244,9 @@ def test_delta_load_end_to_end(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         with requests_mock.Mocker() as m:
             m.get(
                 str(test_settings.fda_source_url),
-                text=HTML_FIXTURE.format(checksum=mock_checksum).replace("09022025", "09092025"),
+                text=HTML_FIXTURE.format(checksum=mock_checksum).replace(
+                    "09022025", "09092025"
+                ),
             )
             m.get(
                 "https://example.com/dm_spl_daily_update_09092025.zip",
@@ -244,7 +258,9 @@ def test_delta_load_end_to_end(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
             delta_result = runner.invoke(app, ["delta-load"])
 
         # 6. Assertions
-        assert delta_result.exit_code == 0, f"CLI command failed with output:\n{delta_result.stdout}"
+        assert delta_result.exit_code == 0, (
+            f"CLI command failed with output:\n{delta_result.stdout}"
+        )
         assert "Delta load process finished successfully" in delta_result.stdout
 
         # 7. Verify data in the database directly
@@ -257,13 +273,17 @@ def test_delta_load_end_to_end(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         )
         with conn.cursor() as cur:
             # Check that the archive was recorded
-            cur.execute("SELECT archive_name, archive_checksum FROM etl_processed_archives")
+            cur.execute(
+                "SELECT archive_name, archive_checksum FROM etl_processed_archives"
+            )
             processed_archive = cur.fetchone()
             assert processed_archive[0] == archive_name
             assert processed_archive[1] == mock_checksum
 
             # Check that the product was loaded
-            cur.execute("SELECT document_id, set_id, product_name, manufacturer_name, dosage_form FROM products")
+            cur.execute(
+                "SELECT document_id, set_id, product_name, manufacturer_name, dosage_form FROM products"
+            )
             product = cur.fetchone()
             assert str(product[0]) == "d1b64b62-050a-4895-924c-d2862d2a6a69"
             assert str(product[1]) == "a2c3b6f0-a38f-4b48-96eb-3b2b403816a4"

--- a/tests/test_cli_full_load_download.py
+++ b/tests/test_cli_full_load_download.py
@@ -1,0 +1,98 @@
+import hashlib
+import zipfile
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from py_load_spl.cli import app
+
+# Fixture for the CLI runner
+runner = CliRunner()
+
+
+# Create a dummy zip file in memory
+@pytest.fixture(scope="session")
+def dummy_zip_content():
+    zip_buffer = BytesIO()
+    with zipfile.ZipFile(zip_buffer, "a", zipfile.ZIP_DEFLATED, False) as zf:
+        zf.writestr("test.xml", "<root>test</root>")
+    zip_buffer.seek(0)
+    return zip_buffer.read()
+
+
+@pytest.fixture(scope="session")
+def dummy_zip_md5(dummy_zip_content):
+    return hashlib.md5(dummy_zip_content).hexdigest()
+
+
+@patch("py_load_spl.cli.get_db_loader")
+def test_full_load_downloads_when_no_source_is_provided(
+    mock_get_db_loader, requests_mock, dummy_zip_content, dummy_zip_md5
+):
+    """
+    Verify that `full-load` without --source triggers the download process.
+    """
+    # Mock the database loader to avoid actual DB operations
+    mock_loader = MagicMock()
+    mock_get_db_loader.return_value = mock_loader
+
+    # Mock the FDA source page with the correct checksum
+    mock_html_content = f"""
+    <html><body><ul class="download">
+        <li><a href="https://example.com/spl_archive_1.zip">HTTPS</a> - MD5 checksum: {dummy_zip_md5}</li>
+        <li><a href="https://example.com/spl_archive_2.zip">HTTPS</a> - MD5 checksum: {dummy_zip_md5}</li>
+    </ul></body></html>
+    """
+    settings_url = (
+        "https://dailymed.nlm.nih.gov/dailymed/spl-resources-all-drug-labels.cfm"
+    )
+    requests_mock.get(settings_url, text=mock_html_content)
+
+    # Mock the archive downloads
+    requests_mock.get(
+        "https://example.com/spl_archive_1.zip", content=dummy_zip_content
+    )
+    requests_mock.get(
+        "https://example.com/spl_archive_2.zip", content=dummy_zip_content
+    )
+
+    # Mock the core logic function to check if it's called
+    with patch("py_load_spl.cli._run_full_load") as mock_run_full_load:
+        result = runner.invoke(app, ["full-load"], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert "Downloading all archives from FDA source" in result.stdout
+        assert "Extracting 2 archives" in result.stdout
+
+        # Verify that the core logic was called
+        mock_run_full_load.assert_called_once()
+        # The second argument is the `source` Path object
+        call_args = mock_run_full_load.call_args[0]
+        assert isinstance(call_args[1], Path)
+
+
+@patch("py_load_spl.cli.get_db_loader")
+def test_full_load_uses_source_when_provided(mock_get_db_loader, tmp_path):
+    """
+    Verify that `full-load` with --source uses the provided path and does not download.
+    """
+    mock_loader = MagicMock()
+    mock_get_db_loader.return_value = mock_loader
+
+    # Create a dummy XML file in the temp source directory
+    source_dir = tmp_path / "xmls"
+    source_dir.mkdir()
+    (source_dir / "test.xml").write_text("<root></root>")
+
+    with patch("py_load_spl.cli._run_full_load") as mock_run_full_load:
+        result = runner.invoke(app, ["full-load", "--source", str(source_dir)])
+
+        assert result.exit_code == 0
+        assert "Downloading all archives" not in result.stdout
+
+        mock_run_full_load.assert_called_once()
+        call_args = mock_run_full_load.call_args[0]
+        assert call_args[1] == source_dir

--- a/tests/test_full_pipeline.py
+++ b/tests/test_full_pipeline.py
@@ -1,8 +1,8 @@
-import pytest
-from unittest.mock import MagicMock, patch
 import tempfile
 from pathlib import Path
-import os
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from py_load_spl.config import DatabaseSettings
 from py_load_spl.db.postgres import PostgresLoader
@@ -82,7 +82,10 @@ def test_full_etl_pipeline_mocked(mock_psycopg2):
     Verifies that the correct data is generated and that the loader methods
     are called as expected.
     """
-    with tempfile.TemporaryDirectory() as source_dir_str, tempfile.TemporaryDirectory() as output_dir_str:
+    with (
+        tempfile.TemporaryDirectory() as source_dir_str,
+        tempfile.TemporaryDirectory() as output_dir_str,
+    ):
         source_dir = Path(source_dir_str)
         output_dir = Path(output_dir_str)
 
@@ -109,7 +112,6 @@ def test_full_etl_pipeline_mocked(mock_psycopg2):
         loader.start_run = MagicMock(return_value=1)
         loader.end_run = MagicMock()
 
-
         # 2. Act: Run the E-T-L process
         # Mimic the parallel execution logic from the CLI
         xml_files = list(source_dir.glob("*.xml"))
@@ -131,7 +133,7 @@ def test_full_etl_pipeline_mocked(mock_psycopg2):
         # Assert that the CSV was created correctly with the new field
         products_csv = output_dir / "products.csv"
         assert products_csv.exists()
-        with open(products_csv, "r") as f:
+        with open(products_csv) as f:
             content = f.read()
             # The order of columns in the model is: document_id, set_id, version_number,
             # effective_time, product_name, manufacturer_name, dosage_form, route_of_administration
@@ -148,8 +150,14 @@ def test_full_etl_pipeline_mocked(mock_psycopg2):
         assert mock_cur.copy_expert.call_count > 0
         # Check that merge_from_staging was called (via execute)
         # It should truncate tables and then insert into them
-        truncate_calls = [call for call in mock_cur.execute.call_args_list if "TRUNCATE" in call[0][0]]
-        insert_calls = [call for call in mock_cur.execute.call_args_list if "INSERT INTO" in call[0][0]]
+        truncate_calls = [
+            call for call in mock_cur.execute.call_args_list if "TRUNCATE" in call[0][0]
+        ]
+        insert_calls = [
+            call
+            for call in mock_cur.execute.call_args_list
+            if "INSERT INTO" in call[0][0]
+        ]
         assert len(truncate_calls) > 0
         assert len(insert_calls) > 0
         print("Verified that database loader methods were called.")
@@ -164,9 +172,10 @@ def test_full_load_pipeline_with_postgres_container(monkeypatch):
     - Runs the 'full-load' CLI command against the test database.
     - Connects to the database to verify the data was loaded correctly.
     """
+    import psycopg2
     from testcontainers.postgres import PostgresContainer
     from typer.testing import CliRunner
-    import psycopg2
+
     from py_load_spl.cli import app
 
     runner = CliRunner()
@@ -220,7 +229,9 @@ def test_full_load_pipeline_with_postgres_container(monkeypatch):
             # Check products table
             cur.execute("SELECT COUNT(*) FROM products;")
             assert cur.fetchone()[0] == 1
-            cur.execute("SELECT product_name, dosage_form, route_of_administration FROM products;")
+            cur.execute(
+                "SELECT product_name, dosage_form, route_of_administration FROM products;"
+            )
             product_row = cur.fetchone()
             assert product_row[0] == "Jules's Sample Drug"
             assert product_row[1] == "TABLET"

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,5 +1,6 @@
-import pytest
 from pathlib import Path
+
+import pytest
 
 from py_load_spl.parsing import parse_spl_file
 
@@ -23,6 +24,9 @@ def sample_spl_file(tmp_path: Path) -> Path:
             <name>JULAMYCIN</name>
           </genericMedicine>
         </asEntityWithGeneric>
+        <asEquivalentEntity>
+            <code code="12345-678" codeSystem="2.16.840.1.113883.6.69" />
+        </asEquivalentEntity>
         <ingredient classCode="ACT">
           <quantity>
             <numerator value="100" unit="mg" />
@@ -174,7 +178,9 @@ def test_parsing_multiple_marketing_statuses(spl_file_with_multiple_statuses: Pa
     assert len(parsed_data["marketing_status"]) == 2
 
     # Sort by start_date for predictable order
-    statuses = sorted(parsed_data["marketing_status"], key=lambda x: x.get("start_date"))
+    statuses = sorted(
+        parsed_data["marketing_status"], key=lambda x: x.get("start_date")
+    )
 
     assert statuses[0]["marketing_category"] == "completed"
     assert statuses[0]["start_date"] == "20240101"

--- a/tests/test_postgres_loader.py
+++ b/tests/test_postgres_loader.py
@@ -1,8 +1,9 @@
-import pytest
-import psycopg2
-from testcontainers.postgres import PostgresContainer
-from uuid import UUID, uuid4
 from datetime import date
+from uuid import uuid4
+
+import psycopg2
+import pytest
+from testcontainers.postgres import PostgresContainer
 
 from py_load_spl.config import DatabaseSettings
 from py_load_spl.db.postgres import PostgresLoader
@@ -126,7 +127,11 @@ def test_merge_from_staging_delta_load(postgres_loader: PostgresLoader):
     postgres_loader.initialize_schema()
     settings = postgres_loader.settings
     conn = psycopg2.connect(
-        dbname=settings.name, user=settings.user, password=settings.password, host=settings.host, port=settings.port
+        dbname=settings.name,
+        user=settings.user,
+        password=settings.password,
+        host=settings.host,
+        port=settings.port,
     )
 
     # ID for the document that will be updated
@@ -143,14 +148,28 @@ def test_merge_from_staging_delta_load(postgres_loader: PostgresLoader):
             INSERT INTO spl_raw_documents (document_id, set_id, version_number, effective_time, raw_data)
             VALUES (%s, %s, 1, %s, '{}'), (%s, %s, 1, %s, '{}');
             """,
-            (str(untouched_doc_id), str(uuid4()), date(2024, 1, 1), str(updated_doc_id), str(uuid4()), date(2024, 1, 1))
+            (
+                str(untouched_doc_id),
+                str(uuid4()),
+                date(2024, 1, 1),
+                str(updated_doc_id),
+                str(uuid4()),
+                date(2024, 1, 1),
+            ),
         )
         cur.execute(
             """
             INSERT INTO products (document_id, set_id, version_number, effective_time, product_name)
             VALUES (%s, %s, 1, %s, 'Untouched Product'), (%s, %s, 1, %s, 'Original Product Name');
             """,
-            (str(untouched_doc_id), str(uuid4()), date(2024, 1, 1), str(updated_doc_id), str(uuid4()), date(2024, 1, 1))
+            (
+                str(untouched_doc_id),
+                str(uuid4()),
+                date(2024, 1, 1),
+                str(updated_doc_id),
+                str(uuid4()),
+                date(2024, 1, 1),
+            ),
         )
         # Insert a child record for the document that will be updated
         cur.execute(
@@ -158,7 +177,7 @@ def test_merge_from_staging_delta_load(postgres_loader: PostgresLoader):
             INSERT INTO ingredients (document_id, ingredient_name, is_active_ingredient)
             VALUES (%s, 'Original Ingredient', true);
             """,
-            (str(updated_doc_id),)
+            (str(updated_doc_id),),
         )
     conn.commit()
 
@@ -170,7 +189,7 @@ def test_merge_from_staging_delta_load(postgres_loader: PostgresLoader):
             INSERT INTO products_staging (document_id, set_id, version_number, effective_time, product_name)
             VALUES (%s, %s, 2, %s, 'Updated Product Name');
             """,
-            (str(updated_doc_id), str(uuid4()), date(2024, 2, 1))
+            (str(updated_doc_id), str(uuid4()), date(2024, 2, 1)),
         )
         # Stage a new child record for the updated document
         cur.execute(
@@ -178,7 +197,7 @@ def test_merge_from_staging_delta_load(postgres_loader: PostgresLoader):
             INSERT INTO ingredients_staging (document_id, ingredient_name, is_active_ingredient)
             VALUES (%s, 'Updated Ingredient', true);
             """,
-            (str(updated_doc_id),)
+            (str(updated_doc_id),),
         )
         # Stage the 'new' document
         cur.execute(
@@ -186,7 +205,7 @@ def test_merge_from_staging_delta_load(postgres_loader: PostgresLoader):
             INSERT INTO products_staging (document_id, set_id, version_number, effective_time, product_name)
             VALUES (%s, %s, 1, %s, 'New Product');
             """,
-            (str(new_doc_id), str(uuid4()), date(2024, 3, 1))
+            (str(new_doc_id), str(uuid4()), date(2024, 3, 1)),
         )
     conn.commit()
 
@@ -200,28 +219,42 @@ def test_merge_from_staging_delta_load(postgres_loader: PostgresLoader):
         assert cur.fetchone()[0] == 3
 
         # Check that the 'untouched' product is still version 1
-        cur.execute("SELECT version_number FROM products WHERE document_id = %s", (str(untouched_doc_id),))
+        cur.execute(
+            "SELECT version_number FROM products WHERE document_id = %s",
+            (str(untouched_doc_id),),
+        )
         assert cur.fetchone()[0] == 1
 
         # Check that the 'updated' product is now version 2
-        cur.execute("SELECT version_number, product_name FROM products WHERE document_id = %s", (str(updated_doc_id),))
+        cur.execute(
+            "SELECT version_number, product_name FROM products WHERE document_id = %s",
+            (str(updated_doc_id),),
+        )
         version, name = cur.fetchone()
         assert version == 2
         assert name == "Updated Product Name"
 
         # Check that the 'new' product exists
-        cur.execute("SELECT product_name FROM products WHERE document_id = %s", (str(new_doc_id),))
+        cur.execute(
+            "SELECT product_name FROM products WHERE document_id = %s",
+            (str(new_doc_id),),
+        )
         assert cur.fetchone()[0] == "New Product"
 
         # Check that the child records for the updated product were replaced
-        cur.execute("SELECT ingredient_name FROM ingredients WHERE document_id = %s", (str(updated_doc_id),))
+        cur.execute(
+            "SELECT ingredient_name FROM ingredients WHERE document_id = %s",
+            (str(updated_doc_id),),
+        )
         ingredients = [row[0] for row in cur.fetchall()]
         assert ingredients == ["Updated Ingredient"]
 
         # Check that the child records for the untouched product are still there
-        cur.execute("SELECT count(*) FROM ingredients WHERE document_id = %s", (str(untouched_doc_id),))
+        cur.execute(
+            "SELECT count(*) FROM ingredients WHERE document_id = %s",
+            (str(untouched_doc_id),),
+        )
         assert cur.fetchone()[0] == 1
-
 
         # Check that staging tables are empty
         cur.execute("SELECT count(*) FROM products_staging")

--- a/tests/test_postgres_loader_optimizations.py
+++ b/tests/test_postgres_loader_optimizations.py
@@ -1,5 +1,5 @@
-import pytest
 import psycopg2
+import pytest
 from testcontainers.postgres import PostgresContainer
 
 from py_load_spl.config import DatabaseSettings
@@ -84,7 +84,6 @@ def test_full_load_optimization_lifecycle(loader: PostgresLoader):
     assert "idx_products_versioning" in initial_indexes
     # We already assert the count of FKs, checking for one specific name
     # is brittle, as was just proven. The count is sufficient.
-
 
     # 2. Act: Run the pre-load optimization
     loader.pre_load_optimization(mode="full-load")

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -1,7 +1,7 @@
+from pathlib import Path
+
 import pytest
 from typer.testing import CliRunner
-from pathlib import Path
-import logging
 
 from py_load_spl.cli import app
 from py_load_spl.config import Settings
@@ -45,14 +45,28 @@ SAMPLE_XML_CONTENT_BAD = """<?xml version="1.0" encoding="UTF-8"?>
 
 class MockLoader:
     """A mock loader that does nothing but allows the CLI to run."""
+
     def __init__(self, db_settings):
         pass
-    def start_run(self, mode): return 1
-    def end_run(self, *args, **kwargs): pass
-    def pre_load_optimization(self, mode): pass
-    def bulk_load_to_staging(self, intermediate_dir): pass
-    def merge_from_staging(self, mode): pass
-    def post_load_cleanup(self, mode): pass
+
+    def start_run(self, mode):
+        return 1
+
+    def end_run(self, *args, **kwargs):
+        pass
+
+    def pre_load_optimization(self, mode):
+        pass
+
+    def bulk_load_to_staging(self, intermediate_dir):
+        pass
+
+    def merge_from_staging(self, mode):
+        pass
+
+    def post_load_cleanup(self, mode):
+        pass
+
 
 @pytest.fixture
 def mock_db_and_settings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
@@ -63,6 +77,7 @@ def mock_db_and_settings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     monkeypatch.setattr("py_load_spl.cli.get_settings", lambda: test_settings)
     monkeypatch.setattr("py_load_spl.cli.PostgresLoader", MockLoader)
     return test_settings
+
 
 def test_full_load_quarantines_bad_xml(
     tmp_path: Path,


### PR DESCRIPTION
The 'full-load' command now automatically downloads and extracts all SPL archives from the FDA source if no local --source path is provided.

This aligns the command's functionality with the automation goals of the FRD (F001.1) and improves user experience by removing manual steps.

- Refactored the `full-load` command in `cli.py` to support the new workflow.
- Added a `download_all_archives` function to `acquisition.py` to handle the non-stateful download of all archives.
- Added unit tests for the new CLI functionality.
- Fixed a pre-existing bug in the parsing tests where the test data did not match the assertions.
- Corrected several linting and typing errors in the modified files to improve code quality.