### PR TITLE
feat: Store raw SPL data as JSONB instead of TEXT

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "postgresql"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:ff7133d75d16ef32aba3532dd00f1b011c8da1e537c95a25b57af2d13c8dab4b"
+content_hash = "sha256:706928b7b02365b3c9e767cb1a8c5dab69ca1be5fa5d608e3c0d98157431e477"
 
 [[metadata.targets]]
 requires_python = "==3.12.*"
@@ -1301,4 +1301,15 @@ files = [
     {file = "wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6"},
     {file = "wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22"},
     {file = "wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0"},
+]
+
+[[package]]
+name = "xmltodict"
+version = "0.15.1"
+requires_python = ">=3.9"
+summary = "Makes working with XML feel like you are working with JSON"
+groups = ["default"]
+files = [
+    {file = "xmltodict-0.15.1-py2.py3-none-any.whl", hash = "sha256:dcd84b52f30a15be5ac4c9099a0cb234df8758624b035411e329c5c1e7a49089"},
+    {file = "xmltodict-0.15.1.tar.gz", hash = "sha256:3d8d49127f3ce6979d40a36dbcad96f8bab106d232d24b49efdd4bd21716983c"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "beautifulsoup4>=4.13.5",
     "python-json-logger>=2.0.7",
     "pyarrow>=21.0.0",
+    "xmltodict>=0.15.1",
 ]
 readme = "README.md"
 

--- a/src/py_load_spl/db/sql/postgres_schema.sql
+++ b/src/py_load_spl/db/sql/postgres_schema.sql
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS spl_raw_documents (
     set_id UUID,
     version_number INT,
     effective_time DATE,
-    raw_data TEXT,
+    raw_data JSONB,
     source_filename TEXT,
     loaded_at TIMESTAMPTZ DEFAULT now()
 );
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS spl_raw_documents_staging (
     set_id UUID,
     version_number INT,
     effective_time DATE,
-    raw_data TEXT,
+    raw_data JSONB,
     source_filename TEXT,
     loaded_at TIMESTAMPTZ DEFAULT now()
 );

--- a/src/py_load_spl/transformation.py
+++ b/src/py_load_spl/transformation.py
@@ -95,11 +95,16 @@ class CsvWriter(FileWriter):
 
         filename = f"{file_base_name}.csv"
         writer = self._csv_writers[filename]
-        dumped = model_instance.model_dump()
 
-        # The raw_data field in SplRawDocument is already a string.
-        # The parser is responsible for converting the XML content to a string.
-        # No extra JSON dumping is needed here.
+        # If the model is SplRawDocument, convert raw_data from XML to JSON string
+        if isinstance(model_instance, SplRawDocument) and model_instance.raw_data:
+            import xmltodict
+            import json
+            xml_string = model_instance.raw_data
+            json_string = json.dumps(xmltodict.parse(xml_string))
+            model_instance.raw_data = json_string
+
+        dumped = model_instance.model_dump()
 
         row = ["\\N" if v is None else v for v in dumped.values()]
         writer.writerow(row)
@@ -142,10 +147,16 @@ class ParquetWriter(FileWriter):
         if not file_base_name:
             raise TypeError(f"No Parquet mapping for model type: {model_type}")
 
+        # If the model is SplRawDocument, convert raw_data from XML to JSON string
+        if isinstance(model_instance, SplRawDocument) and model_instance.raw_data:
+            import xmltodict
+            import json
+            xml_string = model_instance.raw_data
+            json_string = json.dumps(xmltodict.parse(xml_string))
+            model_instance.raw_data = json_string
+
         dumped = model_instance.model_dump()
 
-        # The raw_data field in SplRawDocument is already a string.
-        # No extra JSON dumping is needed. It is handled by the model.
         self._batches[file_base_name].append(dumped)
         self.stats[f"{file_base_name}.parquet"] += 1
 

--- a/tests/test_parquet_writer.py
+++ b/tests/test_parquet_writer.py
@@ -34,7 +34,7 @@ def test_parquet_writer_writes_correct_data():
             set_id=uuid4(),
             version_number=2,
             effective_time="20250910",
-            raw_data=json.dumps({"section": {"title": "Warnings", "text": "May cause drowsiness."}}),
+            raw_data="<section><title>Warnings</title><text>May cause drowsiness.</text></section>",
             source_filename="test.zip/test.xml",
         )
 


### PR DESCRIPTION
This commit updates the application to store the raw SPL data in a JSONB column in PostgreSQL, as recommended by the FRD for improved performance and queryability.

Changes:
- Added `xmltodict` as a dependency to handle XML to JSON conversion.
- Updated the `postgres_schema.sql` to change the `raw_data` column from TEXT to JSONB.
- Modified the `CsvWriter` and `ParquetWriter` in `transformation.py` to convert the raw XML string to a JSON string before writing to intermediate files.
- Fixed a failing test to provide valid XML data, ensuring the new transformation logic is correctly tested.