### PR TITLE
refactor(transformation): Implement batch writing in ParquetWriter

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "postgresql"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:706928b7b02365b3c9e767cb1a8c5dab69ca1be5fa5d608e3c0d98157431e477"
+content_hash = "sha256:7e8dcd7b82c183b9595eadb5313e7f27cba95833ddbce975173a421cd83e40cf"
 
 [[metadata.targets]]
 requires_python = "==3.12.*"
@@ -939,6 +939,20 @@ dependencies = [
 files = [
     {file = "pytest_cov-6.3.0-py3-none-any.whl", hash = "sha256:440db28156d2468cafc0415b4f8e50856a0d11faefa38f30906048fe490f1749"},
     {file = "pytest_cov-6.3.0.tar.gz", hash = "sha256:35c580e7800f87ce892e687461166e1ac2bcb8fb9e13aea79032518d6e503ff2"},
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.0"
+requires_python = ">=3.9"
+summary = "Thin-wrapper around the mock package for easier use with pytest"
+groups = ["dev"]
+dependencies = [
+    "pytest>=6.2.5",
+]
+files = [
+    {file = "pytest_mock-3.15.0-py3-none-any.whl", hash = "sha256:ef2219485fb1bd256b00e7ad7466ce26729b30eadfc7cbcdb4fa9a92ca68db6f"},
+    {file = "pytest_mock-3.15.0.tar.gz", hash = "sha256:ab896bd190316b9d5d87b277569dfcdf718b2d049a2ccff5f7aca279c002a1cf"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,4 +69,5 @@ dev = [
     "pre-commit",
     "requests-mock>=1.12.1",
     "python-json-logger>=2.0.7",
+    "pytest-mock>=3.12.0",
 ]

--- a/src/py_load_spl/transformation.py
+++ b/src/py_load_spl/transformation.py
@@ -105,45 +105,92 @@ class CsvWriter(FileWriter):
 
 
 class ParquetWriter(FileWriter):
-    """Writes data to Parquet files using PyArrow."""
+    """
+    Writes data to Parquet files in batches using PyArrow to keep memory usage low.
+    This implementation conforms to FRD requirement F005.4.
+    """
+
+    def __init__(self, output_dir: Path, batch_size: int = 100_000):
+        super().__init__(output_dir)
+        self.batch_size = batch_size
+        self._batches: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        self._parquet_writers: dict[str, pq.ParquetWriter] = {}
+        self._schemas: dict[str, pa.Schema] = {}
 
     def _open(self) -> None:
-        self._batches: dict[str, list[dict]] = defaultdict(list)
+        # ParquetWriter instances are created on-the-fly when the first batch for a
+        # given file is written, so there's nothing to do here.
+        pass
 
     def _close(self) -> None:
-        """Converts batches to strings and writes them to Parquet files."""
-        for name, batch in self._batches.items():
-            if not batch:
-                continue
+        """Writes any remaining records in the batches and closes all file writers."""
+        logger.info("Closing Parquet writer and flushing final batches...")
+        for name in list(self._batches.keys()):
+            self._flush_batch(name)
+        for writer in self._parquet_writers.values():
+            writer.close()
+        self._parquet_writers.clear()
 
-            # Bug Fix: Convert UUIDs to strings before writing to Parquet
-            processed_batch = []
-            for record in batch:
-                processed_record = {}
-                for key, value in record.items():
-                    if isinstance(value, UUID):
-                        processed_record[key] = str(value)
-                    else:
-                        processed_record[key] = value
-                processed_batch.append(processed_record)
+    def _preprocess_batch(self, batch: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """
+        Preprocesses a batch of records before writing to Parquet.
+        This is where type conversions, like UUID to string, happen.
+        """
+        processed_batch = []
+        for record in batch:
+            processed_record = {}
+            for key, value in record.items():
+                if isinstance(value, UUID):
+                    processed_record[key] = str(value)
+                else:
+                    processed_record[key] = value
+            processed_batch.append(processed_record)
+        return processed_batch
 
-            try:
-                table = pa.Table.from_pylist(processed_batch)
+    def _flush_batch(self, name: str) -> None:
+        """Writes the current in-memory batch to the corresponding Parquet file."""
+        batch = self._batches[name]
+        if not batch:
+            return
+
+        logger.info(f"Flushing batch of {len(batch)} records to {name}.parquet...")
+        processed_batch = self._preprocess_batch(batch)
+
+        try:
+            table = pa.Table.from_pylist(
+                processed_batch, schema=self._schemas.get(name)
+            )
+
+            if name not in self._parquet_writers:
+                # First time writing to this file, create the writer and store schema
                 filepath = self.output_dir / f"{name}.parquet"
-                pq.write_table(table, filepath)
-            except Exception as e:
-                logger.error(f"Failed to write Parquet file for {name}. Error: {e}")
+                self._schemas[name] = table.schema
+                self._parquet_writers[name] = pq.ParquetWriter(filepath, table.schema)
+
+            self._parquet_writers[name].write_table(table)
+            self._batches[name].clear()
+        except Exception as e:
+            logger.error(
+                f"Failed to write Parquet batch for {name}. Error: {e}", exc_info=True
+            )
+            raise
 
     def write(self, model_instance: BaseModel) -> None:
+        """
+        Appends a model instance to the appropriate in-memory batch.
+        If a batch reaches the defined `batch_size`, it is flushed to a file.
+        """
         model_type = type(model_instance)
         file_base_name = MODEL_TO_FILENAME_MAP.get(model_type)
         if not file_base_name:
             raise TypeError(f"No Parquet mapping for model type: {model_type}")
 
         dumped = model_instance.model_dump()
-
         self._batches[file_base_name].append(dumped)
         self.stats[f"{file_base_name}.parquet"] += 1
+
+        if len(self._batches[file_base_name]) >= self.batch_size:
+            self._flush_batch(file_base_name)
 
 
 # --- Transformer ---

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 import pyarrow.parquet as pq
 import pytest
+from pytest_mock import MockerFixture
 
 from py_load_spl.transformation import (
     CsvWriter,
@@ -113,3 +114,54 @@ def test_transformer_with_different_writers(
         assert ing_row["document_id"] == "d1b64b62-050a-4895-924c-d2862d2a6a69"
         assert ing_row["ingredient_name"] == "JULESTAT"
         assert ing_row["is_active_ingredient"] is True
+
+
+def test_parquet_writer_batching(tmp_path: Path, mocker: MockerFixture) -> None:
+    """
+    Tests that the ParquetWriter correctly writes data in batches to manage memory.
+    """
+    # 1. Arrange
+    output_dir = tmp_path / "test_output"
+    # Use a small batch size to easily trigger the flushing mechanism
+    writer = ParquetWriter(output_dir, batch_size=2)
+    transformer = Transformer(writer=writer)
+
+    # Create 3 records. With a batch size of 2, this should trigger one flush
+    # during the write operations, and one flush on close.
+    record2 = SAMPLE_PARSED_RECORD.copy()
+    record2["document_id"] = UUID("a" * 32)
+    record3 = SAMPLE_PARSED_RECORD.copy()
+    record3["document_id"] = UUID("b" * 32)
+    parsed_data_stream = [SAMPLE_PARSED_RECORD, record2, record3]
+
+    # Spy on the method that writes to the file
+    spy = mocker.spy(writer, "_flush_batch")
+
+    # 2. Act
+    transformer.transform_stream(parsed_data_stream)
+
+    # 3. Assert
+    # _flush_batch should be called once for 'products' when the 2nd record is processed,
+    # and then once for each table with remaining data when the writer is closed.
+    assert spy.call_count > 1
+
+    # Check the call for the 'products' table specifically.
+    # It should have been called once for the first batch, and once on close.
+    products_flush_calls = [
+        call for call in spy.call_args_list if call.args[0] == "products"
+    ]
+    assert len(products_flush_calls) == 2
+
+    # Verify the final file contains all records
+    products_file = output_dir / "products.parquet"
+    assert products_file.exists()
+    table = pq.read_table(products_file)
+    assert table.num_rows == 3
+
+    # Verify document_ids to ensure all records are present
+    doc_ids = {str(row["document_id"]) for row in table.to_pylist()}
+    assert doc_ids == {
+        "d1b64b62-050a-4895-924c-d2862d2a6a69",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+    }


### PR DESCRIPTION
The previous implementation of the `ParquetWriter` buffered all records in memory before writing them to a file. This could lead to high memory consumption on large datasets, violating the memory-efficiency goals of the project (FRD N001.1).

This change refactors the `ParquetWriter` to write data in batches, adhering to FRD requirement F005.4.

Key changes:
- The `ParquetWriter` now uses `pyarrow.parquet.ParquetWriter` to append record batches to the Parquet file.
- A `batch_size` parameter is introduced to control how many records are buffered in memory before being flushed to disk.
- The `write` method now triggers a flush when the batch size is reached.
- The `_close` method ensures any remaining records in the final batch are written.

A new test case, `test_parquet_writer_batching`, has been added to `tests/test_transformation.py` to verify the batching mechanism. This test uses `pytest-mock` to spy on the internal `_flush_batch` method and asserts that it is called as expected.