### PR TITLE
feat: Add retry logic to data acquisition

### DIFF
--- a/src/py_load_spl/acquisition.py
+++ b/src/py_load_spl/acquisition.py
@@ -13,6 +13,13 @@ from rich.progress import (
     TimeRemainingColumn,
     TransferSpeedColumn,
 )
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from .config import Settings, get_settings
 from .db.base import DatabaseLoader
@@ -21,17 +28,22 @@ from .models import Archive
 logger = logging.getLogger(__name__)
 
 
+@retry(
+    retry=retry_if_exception_type(requests.RequestException),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    stop=stop_after_attempt(3),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+)
 def get_archive_list(settings: Settings) -> list[Archive]:
     """
     Scrapes the DailyMed SPL download page to get a list of all available archives.
+    This function is decorated to be resilient to transient network errors.
     """
     logger.info("Fetching archive list from %s", settings.fda_source_url)
-    try:
-        response = requests.get(str(settings.fda_source_url), timeout=60)
-        response.raise_for_status()
-    except requests.RequestException as e:
-        logger.error("Failed to fetch archive list: %s", e)
-        raise
+    # The try/except block is removed as tenacity will handle the exception
+    # and raise a RetryError if all attempts fail.
+    response = requests.get(str(settings.fda_source_url), timeout=60)
+    response.raise_for_status()
 
     soup = BeautifulSoup(response.content, "lxml")
     archives: list[Archive] = []
@@ -43,7 +55,7 @@ def get_archive_list(settings: Settings) -> list[Archive]:
         if not https_link:
             continue
 
-        href = https_link.get("href")
+        href = https_link.get("href")  # type: ignore[attr-defined]
         if not href or not href.endswith(".zip"):
             continue
 
@@ -68,9 +80,17 @@ def get_archive_list(settings: Settings) -> list[Archive]:
     return archives
 
 
+@retry(
+    retry=retry_if_exception_type(requests.RequestException),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    stop=stop_after_attempt(3),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+)
 def download_archive(archive: Archive, settings: Settings) -> Path:
     """
     Downloads a single archive file, verifies its checksum, and saves it.
+
+    This function is decorated to be resilient to transient network errors.
     """
     download_dir = Path(settings.download_path)
     download_dir.mkdir(parents=True, exist_ok=True)
@@ -91,9 +111,11 @@ def download_archive(archive: Archive, settings: Settings) -> Path:
     )
 
     md5 = hashlib.md5()
+    # Tenacity will handle retrying on requests.RequestException.
+    # We still need to handle other potential errors, like checksum mismatches.
     try:
         with requests.get(archive.url, stream=True, timeout=300) as r:
-            r.raise_for_status()
+            r.raise_for_status()  # Let tenacity catch this if it's a network error
             total_size = int(r.headers.get("content-length", 0))
             task_id = progress.add_task(
                 "download", total=total_size, filename=archive.name
@@ -106,16 +128,24 @@ def download_archive(archive: Archive, settings: Settings) -> Path:
 
         calculated_checksum = md5.hexdigest()
         if calculated_checksum.lower() != archive.checksum.lower():
-            file_path.unlink()  # Delete corrupted file
-            raise ValueError(
+            msg = (
                 f"Checksum mismatch for {archive.name}. "
                 f"Expected {archive.checksum}, got {calculated_checksum}."
             )
+            raise ValueError(msg)
         logger.info("Checksum verified for %s", archive.name)
         return file_path
-    except (requests.RequestException, ValueError) as e:
-        logger.error("Failed to download or verify %s: %s", archive.name, e)
-        # Clean up partial download if it exists
+    except ValueError as e:
+        # This will catch the checksum error specifically. We don't want to retry this.
+        logger.error("Data integrity error for %s: %s", archive.name, e)
+        if file_path.exists():
+            file_path.unlink()  # Delete corrupted file
+        raise  # Re-raise the ValueError
+    except Exception as e:
+        # Catch any other unexpected errors during file handling
+        logger.error(
+            "An unexpected error occurred during download of %s: %s", archive.name, e
+        )
         if file_path.exists():
             file_path.unlink(missing_ok=True)
         raise

--- a/src/py_load_spl/main.py
+++ b/src/py_load_spl/main.py
@@ -26,9 +26,9 @@ def get_db_loader(settings: Settings) -> DatabaseLoader:
     elif adapter == "sqlite":
         return SqliteLoader(settings.db)
     elif adapter == "redshift":
-        assert isinstance(
-            settings.db, RedshiftSettings
-        ), "DB adapter is 'redshift' but settings are not RedshiftSettings"
+        assert isinstance(settings.db, RedshiftSettings), (
+            "DB adapter is 'redshift' but settings are not RedshiftSettings"
+        )
         return RedshiftLoader(settings.db, settings.s3)
     else:
         # This path should be unreachable due to Pydantic validation

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
+import requests_mock
+from tenacity import RetryError
 
 from py_load_spl.acquisition import (
     download_all_archives,
@@ -53,7 +55,9 @@ def mock_settings(tmp_path: Path) -> Settings:
     return Settings(download_path=str(tmp_path))
 
 
-def test_get_archive_list(mock_settings: Settings, requests_mock):
+def test_get_archive_list(
+    mock_settings: Settings, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests that the archive list is scraped correctly from the HTML."""
     requests_mock.get(str(mock_settings.fda_source_url), text=SAMPLE_HTML_VALID)
     archives = get_archive_list(mock_settings)
@@ -63,31 +67,63 @@ def test_get_archive_list(mock_settings: Settings, requests_mock):
     assert archives[1].url == "https://example.com/part2.zip"
 
 
-def test_get_archive_list_request_error(mock_settings: Settings, requests_mock):
-    """Tests that a network error during list fetch is handled."""
+def test_get_archive_list_request_error(
+    mock_settings: Settings, requests_mock: requests_mock.Mocker
+) -> None:
+    """
+    Tests that a network error during list fetch is handled and raises RetryError
+    after all attempts are exhausted.
+    """
     requests_mock.get(
         str(mock_settings.fda_source_url),
         exc=requests.RequestException("Network Error"),
     )
-    with pytest.raises(requests.RequestException):
+    # After the tenacity decorator, this should raise RetryError, not the
+    # original exception
+    with pytest.raises(RetryError):
         get_archive_list(mock_settings)
 
 
-def test_get_archive_list_malformed_page(mock_settings: Settings, requests_mock):
+def test_get_archive_list_malformed_page(
+    mock_settings: Settings, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests that the scraper handles malformed or unexpected HTML gracefully."""
     requests_mock.get(str(mock_settings.fda_source_url), text=SAMPLE_HTML_MALFORMED)
     archives = get_archive_list(mock_settings)
     assert len(archives) == 0
 
 
-def test_get_archive_list_no_archives_found(mock_settings: Settings, requests_mock):
+def test_get_archive_list_no_archives_found(
+    mock_settings: Settings, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests the case where the page is valid but contains no archives."""
     requests_mock.get(str(mock_settings.fda_source_url), text="<html></html>")
     archives = get_archive_list(mock_settings)
     assert len(archives) == 0
 
 
-def test_download_archive_success(mock_settings: Settings, requests_mock):
+def test_get_archive_list_retries_on_transient_error(
+    mock_settings: Settings, requests_mock: requests_mock.Mocker
+) -> None:
+    """
+    Tests that the retry decorator correctly handles transient errors and eventually
+    succeeds.
+    """
+    matcher = requests_mock.get(
+        str(mock_settings.fda_source_url),
+        [
+            {"status_code": 503, "text": "Service Unavailable"},
+            {"status_code": 200, "text": SAMPLE_HTML_VALID},
+        ],
+    )
+    archives = get_archive_list(mock_settings)
+    assert len(archives) == 2  # The call should eventually succeed
+    assert matcher.call_count == 2  # It should have been called twice
+
+
+def test_download_archive_success(
+    mock_settings: Settings, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests a successful download and checksum verification."""
     content = b"hello"
     archive = Archive(
@@ -105,7 +141,9 @@ def test_download_archive_success(mock_settings: Settings, requests_mock):
     assert file_path.read_bytes() == content
 
 
-def test_download_archive_checksum_mismatch(mock_settings: Settings, requests_mock):
+def test_download_archive_checksum_mismatch(
+    mock_settings: Settings, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests that a checksum mismatch raises a ValueError and cleans up the file."""
     archive = Archive(
         name="test.zip",
@@ -119,8 +157,12 @@ def test_download_archive_checksum_mismatch(mock_settings: Settings, requests_mo
     assert not file_path.exists()
 
 
-def test_download_archive_network_error(mock_settings: Settings, requests_mock):
-    """Tests that a network error during download is handled and the file is cleaned up."""
+def test_download_archive_network_error(
+    mock_settings: Settings, requests_mock: requests_mock.Mocker
+) -> None:
+    """
+    Tests that a network error during download raises RetryError and cleans up.
+    """
     archive = Archive(
         name="test.zip",
         url="https://example.com/test.zip",
@@ -131,12 +173,14 @@ def test_download_archive_network_error(mock_settings: Settings, requests_mock):
         exc=requests.RequestException("Connection timed out"),
     )
     file_path = Path(mock_settings.download_path) / archive.name
-    with pytest.raises(requests.RequestException):
+    # The decorator will now raise RetryError
+    with pytest.raises(RetryError):
         download_archive(archive, mock_settings)
+    # The cleanup logic is now inside the function's own try/except block
     assert not file_path.exists()
 
 
-def test_download_spl_archives_db_error(mock_settings: Settings):
+def test_download_spl_archives_db_error(mock_settings: Settings) -> None:
     """Tests that the process aborts gracefully if the DB is down."""
     mock_loader = MagicMock()
     mock_loader.get_processed_archives.side_effect = Exception("DB is offline")
@@ -145,8 +189,8 @@ def test_download_spl_archives_db_error(mock_settings: Settings):
 
 
 def test_download_spl_archives_no_archives_at_source(
-    mock_settings: Settings, requests_mock
-):
+    mock_settings: Settings, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests when the scraper finds no archives."""
     mock_loader = MagicMock()
     mock_loader.get_processed_archives.return_value = set()
@@ -155,7 +199,9 @@ def test_download_spl_archives_no_archives_at_source(
     assert result == []
 
 
-def test_download_all_archives_single_failure(mock_settings: Settings, requests_mock):
+def test_download_all_archives_single_failure(
+    mock_settings: Settings, requests_mock: requests_mock.Mocker
+) -> None:
     """Tests that one failed download doesn't stop the whole process."""
     requests_mock.get(str(mock_settings.fda_source_url), text=SAMPLE_HTML_VALID)
     # Make the first archive download fail
@@ -175,7 +221,9 @@ def test_download_all_archives_single_failure(mock_settings: Settings, requests_
     assert downloaded[0].name == "part2.zip"
 
 
-def test_download_all_archives_no_settings(requests_mock):
+def test_download_all_archives_no_settings(
+    requests_mock: requests_mock.Mocker,
+) -> None:
     """Tests that get_settings() is called if no settings are provided."""
     with patch("py_load_spl.acquisition.get_settings") as mock_get_settings:
         mock_settings_instance = Settings()

--- a/tests/test_postgres_loader.py
+++ b/tests/test_postgres_loader.py
@@ -5,7 +5,6 @@ import psycopg2
 import pytest
 from testcontainers.postgres import PostgresContainer
 
-from py_load_spl.config import DatabaseSettings
 from py_load_spl.db.postgres import PostgresLoader
 
 # Mark all tests in this file as integration tests

--- a/tests/test_postgres_loader_errors.py
+++ b/tests/test_postgres_loader_errors.py
@@ -4,11 +4,8 @@ from unittest.mock import MagicMock
 import psycopg2
 import pytest
 
-from py_load_spl.config import DatabaseSettings
+from py_load_spl.config import DatabaseSettings, PostgresSettings
 from py_load_spl.db.postgres import PostgresLoader
-
-
-from py_load_spl.config import PostgresSettings
 
 
 @pytest.fixture

--- a/tests/test_redshift_loader.py
+++ b/tests/test_redshift_loader.py
@@ -1,27 +1,27 @@
 import os
+from collections.abc import Generator
 from pathlib import Path
-from typing import Generator
 from unittest.mock import MagicMock
 
 import boto3
+import psycopg2
 import pytest
 from moto import mock_aws
-from testcontainers.postgres import PostgresContainer
-from pytest_mock import MockerFixture
 from mypy_boto3_s3.client import S3Client
+from pytest_mock import MockerFixture
+from testcontainers.postgres import PostgresContainer
 
 from py_load_spl.config import RedshiftSettings, S3Settings
 from py_load_spl.db.redshift import RedshiftLoader
-
-import psycopg2
-
 
 # Mark all tests in this file as integration tests
 pytestmark = pytest.mark.integration
 
 
 @pytest.fixture(autouse=True)
-def patch_redshift_connector(mocker: MockerFixture, postgres_container: PostgresContainer):
+def patch_redshift_connector(
+    mocker: MockerFixture, postgres_container: PostgresContainer
+):
     """
     Patches redshift_connector.connect to use psycopg2.connect instead,
     allowing tests to run against a standard Postgres container. This is a
@@ -132,7 +132,21 @@ def test_redshift_loader_pipeline(
     )
 
     mock_cursor = MagicMock()
-    mocker.patch.object(redshift_loader, "_get_conn", return_value=mocker.MagicMock(__enter__=mocker.MagicMock(return_value=mocker.MagicMock(cursor=mocker.MagicMock(return_value=mocker.MagicMock(__enter__=mocker.MagicMock(return_value=mock_cursor)))))))
+    mocker.patch.object(
+        redshift_loader,
+        "_get_conn",
+        return_value=mocker.MagicMock(
+            __enter__=mocker.MagicMock(
+                return_value=mocker.MagicMock(
+                    cursor=mocker.MagicMock(
+                        return_value=mocker.MagicMock(
+                            __enter__=mocker.MagicMock(return_value=mock_cursor)
+                        )
+                    )
+                )
+            )
+        ),
+    )
 
     redshift_loader.bulk_load_to_staging(intermediate_dir)
 
@@ -146,7 +160,9 @@ def test_redshift_loader_pipeline(
     call_args, _ = mock_cursor.execute.call_args
     sql_command = call_args[0]
     assert "COPY products_staging" in sql_command
-    assert f"FROM 's3://{s3_bucket_name}/{s3_prefix}/products_staging.csv'" in sql_command
+    assert (
+        f"FROM 's3://{s3_bucket_name}/{s3_prefix}/products_staging.csv'" in sql_command
+    )
     assert f"IAM_ROLE '{redshift_loader.settings.iam_role_arn}'" in sql_command
     assert "FORMAT AS CSV" in sql_command
 
@@ -164,17 +180,26 @@ def test_redshift_merge_logic(
 
     with redshift_loader._get_conn() as conn:
         with conn.cursor() as cur:
-            cur.execute(f"INSERT INTO spl_raw_documents_staging VALUES ('{doc_id}', '{set_id}', 1, '2025-01-01', '{{\"key\": \"value\"}}', 'file.xml', '2025-01-01');")
-            cur.execute(f"INSERT INTO products_staging VALUES ('{doc_id}', '{set_id}', 1, '2025-01-01', 'Prod', 'Mfg', 'Form', 'Route', false, '2025-01-01');")
+            cur.execute(
+                f"INSERT INTO spl_raw_documents_staging VALUES ('{doc_id}', '{set_id}', 1, '2025-01-01', '{{\"key\": \"value\"}}', 'file.xml', '2025-01-01');"
+            )
+            cur.execute(
+                f"INSERT INTO products_staging VALUES ('{doc_id}', '{set_id}', 1, '2025-01-01', 'Prod', 'Mfg', 'Form', 'Route', false, '2025-01-01');"
+            )
         conn.commit()
 
     redshift_loader.merge_from_staging(mode="full-load")
 
     with redshift_loader._get_conn() as conn:
         with conn.cursor() as cur:
-            cur.execute("SELECT COUNT(*) FROM products WHERE document_id = %s", (doc_id,))
+            cur.execute(
+                "SELECT COUNT(*) FROM products WHERE document_id = %s", (doc_id,)
+            )
             assert cur.fetchone()[0] == 1
-            cur.execute("SELECT COUNT(*) FROM spl_raw_documents WHERE document_id = %s", (doc_id,))
+            cur.execute(
+                "SELECT COUNT(*) FROM spl_raw_documents WHERE document_id = %s",
+                (doc_id,),
+            )
             assert cur.fetchone()[0] == 1
 
             cur.execute("SELECT COUNT(*) FROM products_staging;")

--- a/tests/test_sqlite_loader.py
+++ b/tests/test_sqlite_loader.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from py_load_spl.config import DatabaseSettings, Settings
+from py_load_spl.config import Settings
 from py_load_spl.db.sqlite import SqliteLoader
 
 # Mark all tests in this file as integration tests


### PR DESCRIPTION
Implements NFR N002.2 from the FRD by adding a robust retry mechanism to the data acquisition functions.

- Uses the `tenacity` library to decorate `get_archive_list` and `download_archive` functions.
- The retry logic is triggered by `requests.RequestException`, uses exponential backoff, and attempts up to 3 times.
- This makes the ETL pipeline more resilient to transient network failures during the download process.
- Updates existing tests to expect `tenacity.RetryError` on persistent failures.
- Adds a new unit test to verify that the retry mechanism is triggered on transient failures and eventually succeeds.
- Cleans up linter and mypy errors in the modified files to adhere to project quality standards.